### PR TITLE
Fixed compiler warnings about integer overflow.

### DIFF
--- a/Enemy.h
+++ b/Enemy.h
@@ -5,12 +5,12 @@
 class Enemy
 {
   public:
-    void Spawn(int pos, bool dir, uint8_t speed, uint8_t wobble);
+    void Spawn(int pos, bool dir, uint8_t speed, uint16_t wobble);
     void Tick();
     void Kill();
     bool Alive();
     int _pos;
-    uint8_t _wobble;
+    uint16_t _wobble;
     uint8_t playerSide;
   private:
     bool _dir;
@@ -19,7 +19,7 @@ class Enemy
     int _origin;
 };
 
-void Enemy::Spawn(int pos, bool dir, uint8_t speed, uint8_t wobble){
+void Enemy::Spawn(int pos, bool dir, uint8_t speed, uint16_t wobble){
     _pos = pos;
     _dir = dir;          // 0 = left, 1 = right
     _wobble = wobble;    // 0 = no, >0 = yes, value is width of wobble

--- a/TWANG.ino
+++ b/TWANG.ino
@@ -514,7 +514,7 @@ void moveBoss(){
 
    ==============================================================================
 */
-void spawnEnemy(int pos, bool dir, uint8_t speed, uint8_t wobble){
+void spawnEnemy(int pos, bool dir, uint8_t speed, uint16_t wobble){
     for(uint8_t e = 0; e<ENEMY_COUNT; e++){  // look for one that is not alive for a place to add one
         if(!enemyPool[e].Alive()){
             enemyPool[e].Spawn(pos, dir, speed, wobble);


### PR DESCRIPTION
```
/Volumes/zbitpit/Repositories/TWANG/nuess0r/TWANG/TWANG.ino: In function 'void loadLevel()':
/Volumes/zbitpit/Repositories/TWANG/nuess0r/TWANG/TWANG.ino:391:38: warning: large integer implicitly truncated to unsigned type [-Woverflow]
             spawnEnemy(700, 1, 7, 275);
                                      ^
/Volumes/zbitpit/Repositories/TWANG/nuess0r/TWANG/TWANG.ino:408:38: warning: large integer implicitly truncated to unsigned type [-Woverflow]
             spawnEnemy(700, 1, 7, 275);
                                      ^
/Volumes/zbitpit/Repositories/TWANG/nuess0r/TWANG/TWANG.ino:411:38: warning: large integer implicitly truncated to unsigned type [-Woverflow]
             spawnEnemy(800, 1, 5, 350);
                                      ^
```